### PR TITLE
Add FlairID and FlairName properties to DriverModel

### DIFF
--- a/IRacingSdkSessionInfo.cs
+++ b/IRacingSdkSessionInfo.cs
@@ -325,7 +325,9 @@ namespace IRSDKSharper
 				public int DivisionID { get; set; }
 				public int CurDriverIncidentCount { get; set; }
 				public int TeamIncidentCount { get; set; }
-			}
+                public int FlairID { get; set; }
+                public string FlairName { get; set; }
+            }
 		}
 
 		public class SplitTimeInfoModel


### PR DESCRIPTION
Fixes #8 

Support for accessing the new iRacing values:
int FlairID
string FlairName 

These properties are now available in the DriverModel for accessing the flair information from the session data.